### PR TITLE
Sync changes for Bio-Formats 5.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>bio-formats_plugins</artifactId>
-  <version>5.3.5-SNAPSHOT</version>
+  <version>5.8.2</version>
 
   <name>Bio-Formats Plugins for ImageJ</name>
   <description>A collection of plugins for ImageJ, including the Bio-Formats Importer, Bio-Formats Exporter, Bio-Formats Macro Extensions, Data Browser and Stack Slicer.</description>
@@ -161,7 +161,7 @@
   </dependencies>
 
   <properties>
-    <bioformats.version>5.7.3</bioformats.version>
+    <bioformats.version>5.8.2</bioformats.version>
     <imagej1.version>1.52a</imagej1.version>
     <jgoodies-forms.version>1.7.2</jgoodies-forms.version>
     <logback.version>1.1.1</logback.version>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
 
   <properties>
     <bioformats.version>5.7.3</bioformats.version>
-    <imagej1.version>1.51r</imagej1.version>
+    <imagej1.version>1.52a</imagej1.version>
     <jgoodies-forms.version>1.7.2</jgoodies-forms.version>
     <logback.version>1.1.1</logback.version>
     <slf4j.version>1.7.6</slf4j.version>

--- a/src/main/java/loci/plugins/macro/LociFunctions.java
+++ b/src/main/java/loci/plugins/macro/LociFunctions.java
@@ -467,7 +467,10 @@ public class LociFunctions extends MacroFunctions {
     MetadataRetrieve retrieve = (MetadataRetrieve) r.getMetadataStore();
     Double val = null;
     if (planeIndex >= 0) {
-      val = retrieve.getPlaneExposureTime(imageIndex, planeIndex).value(UNITS.SECOND).doubleValue();
+      Time valTime = retrieve.getPlaneExposureTime(imageIndex, planeIndex);
+      if (valTime != null) {
+        val = valTime.value(UNITS.SECOND).doubleValue();
+      }
     }
     exposureTime[0] = val == null ? new Double(Double.NaN) : val;
   }

--- a/src/main/java/loci/plugins/out/Exporter.java
+++ b/src/main/java/loci/plugins/out/Exporter.java
@@ -609,6 +609,7 @@ public class Exporter {
             if (notSupportedType) {
                 IJ.error("Pixel type (" + FormatTools.getPixelTypeString(thisType) +
                         ") not supported by this format.");
+                return;
             }
 
             if (codecs != null && codecs.length > 1) {


### PR DESCRIPTION
See [trello](https://trello.com/c/IaqwRcg6/22-update-repositories-for-582).

- Update code changed for Bio-Formats 5.8.2
- Update Bio-Formats and ImageJ versions in the pom

This can be tagged as `v5.8.2` once merged, to mark the syncronisation with the Bio-Formats Java changes for 5.8.2.

Testing with ImageJ:

- Download [Fiji](https://downloads.imagej.net/fiji/latest/fiji-nojre.zip)
- Unpack
- Delete `bio-formats_plugins` from `plugins`
- Build this repo with `mvn`, and copy the plugin from `target` into the Fiji `plugins` directory
- Run Fiji and the Bio-Formats Importer etc.

Differences with the Bio-Formats jar:

- Unpack Fiji download
- run `pkgdiff` e.g. `pkgdiff ~/Fiji.app/plugins/bio-formats_plugins-5.8.2.jar ~/code/bio-formats-imagej/target/bio-formats_plugins-5.8.2.jar`
- check the HTML report; you'll see trivial metadata differences only (no missing/changed classes or data files)

These tests should demonstrate that this repository is producing an ImageJ plugin which is a compatible drop-in replacement for the jar in the 5.8.2 Bio-Formats release, and which can fully replace it for 5.9.0