### PR TITLE
build: Never run upgrade checker when running tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,9 @@ Data Browser and Stack Slicer.</projectName>
           <suiteXmlFiles>
             <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
           </suiteXmlFiles>
+          <systemPropertyVariables>
+            <bioformats_can_do_upgrade_check>false</bioformats_can_do_upgrade_check>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
This results in unnecessary hits and biased statistics.  Add `bioformats_can_do_upgrade_check=false` to all test invocations.

See: https://github.com/openmicroscopy/bioformats/pull/3142

Testing: check CI builds are green.